### PR TITLE
Update dsnet.service

### DIFF
--- a/etc/dsnet.service
+++ b/etc/dsnet.service
@@ -10,6 +10,7 @@ Type=oneshot
 ExecStart=/usr/local/bin/dsnet up
 ExecStop=/usr/local/bin/dsnet down
 RemainAfterExit=yes
+ExecReload=/usr/local/bin/dsnet sync
 
 [Install]
 WantedBy=default.target

--- a/etc/dsnet.service
+++ b/etc/dsnet.service
@@ -8,6 +8,8 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 ExecStart=/usr/local/bin/dsnet up
+ExecStop=/usr/local/bin/dsnet down
+RemainAfterExit=yes
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
This commit makes the dsnet connection manageable by systemctl start/stop/restart.
Otherwise, systemctl stop does not bring the dsnet down and restart fails.
RemainAfterExit is added so that systemctl status reports Active.
I'm not sure whether dsnet sync could be used with ExecReload, so I did not include it.
Later on, if/when creating packages for linux repositories, it's customary to send the package to /usr/bin instead of /usr/local/bin, so just gotta keep in mind to update the service file accordingly too.