### PR TITLE
IPv6 support

### DIFF
--- a/add.go
+++ b/add.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-const wgQuickPeerConf = `[Interface]
+const wgQuickPeerConf = `[Interface
 Address={{ .Peer.IP }}/22
 Address={{ .Peer.IP6 }}/64
 PrivateKey={{ .Peer.PrivateKey.Key }}
@@ -46,7 +46,11 @@ set interfaces wireguard wg0 description {{ conf.InterfaceName }}
 #set service dns forwarding name-server {{ .DsnetConfig.DNS }}
 {{ end }}
 
+{{ if gt (.DsnetConfig.ExternalIP | len) 0 -}}
 set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} endpoint {{ .DsnetConfig.ExternalIP }}:{{ .DsnetConfig.ListenPort }}
+{{ else -}}
+set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} endpoint {{ .DsnetConfig.ExternalIP6 }}:{{ .DsnetConfig.ListenPort }}
+{{ end -}}
 set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} persistent-keepalive {{ .Keepalive }}
 set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} preshared-key {{ .Peer.PresharedKey.Key }}
 {{ with .DsnetConfig.Network -}}

--- a/add.go
+++ b/add.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-const wgQuickPeerConf = `[Interface
+const wgQuickPeerConf = `[Interface]
 Address={{ .Peer.IP }}/22
 Address={{ .Peer.IP6 }}/64
 PrivateKey={{ .Peer.PrivateKey.Key }}

--- a/add.go
+++ b/add.go
@@ -96,13 +96,10 @@ func Add() {
 }
 
 func PrintPeerCfg(peer PeerConfig, conf *DsnetConfig) {
-	allowedIPsStr := make([]string, len(conf.Networks)+2)
-	allowedIPsStr[0] = conf.Network.String()
-	allowedIPsStr[1] = conf.Network6.String()
-
-	for i, net := range conf.Networks {
-		allowedIPsStr[i+2] = net.String()
-	}
+	allowedIPs := make([]JSONIPNet, len(conf.Networks)+2)
+	allowedIPs[0] = conf.Network
+	allowedIPs[1] = conf.Network6
+	allowedIPs = append(allowedIPs, conf.Networks...)
 
 	var peerConf string
 
@@ -124,7 +121,7 @@ func PrintPeerCfg(peer PeerConfig, conf *DsnetConfig) {
 		"Peer":        peer,
 		"DsnetConfig": conf,
 		"Keepalive":   time.Duration(KEEPALIVE).Seconds(),
-		"AllowedIPs":  allowedIPsStr,
+		"AllowedIPs":  allowedIPs,
 		"Cidrmask":    cidrmask,
 	})
 	check(err)

--- a/add.go
+++ b/add.go
@@ -19,7 +19,11 @@ DNS={{ .DsnetConfig.DNS }}
 [Peer]
 PublicKey={{ .DsnetConfig.PrivateKey.PublicKey.Key }}
 PresharedKey={{ .Peer.PresharedKey.Key }}
+{{ if gt (.DsnetConfig.ExternalIP | len) 0 -}}
 Endpoint={{ .DsnetConfig.ExternalIP }}:{{ .DsnetConfig.ListenPort }}
+{{ else -}}
+Endpoint={{ .DsnetConfig.ExternalIP6 }}:{{ .DsnetConfig.ListenPort }}
+{{ end -}}
 PersistentKeepalive={{ .Keepalive }}
 {{ with .DsnetConfig.Network -}}
 AllowedIPs={{ . }}

--- a/add.go
+++ b/add.go
@@ -21,9 +21,15 @@ PublicKey={{ .DsnetConfig.PrivateKey.PublicKey.Key }}
 PresharedKey={{ .Peer.PresharedKey.Key }}
 Endpoint={{ .DsnetConfig.ExternalIP }}:{{ .DsnetConfig.ListenPort }}
 PersistentKeepalive={{ .Keepalive }}
-{{ range .AllowedIPs -}}
+{{ with .DsnetConfig.Network -}}
 AllowedIPs={{ . }}
-{{ end }}
+{{ end -}}
+{{ with .DsnetConfig.Network6 -}}
+AllowedIPs={{ . }}
+{{ end -}}
+{{ range .DsnetConfig.Networks -}}
+AllowedIPs={{ . }}
+{{ end -}}
 `
 
 // TODO use random wg0-wg999 to hopefully avoid conflict by default?
@@ -39,9 +45,15 @@ set interfaces wireguard wg0 description {{ conf.InterfaceName }}
 set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} endpoint {{ .DsnetConfig.ExternalIP }}:{{ .DsnetConfig.ListenPort }}
 set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} persistent-keepalive {{ .Keepalive }}
 set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} preshared-key {{ .Peer.PresharedKey.Key }}
-{{ range .AllowedIPs -}}
+{{ with .DsnetConfig.Network -}}
 set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} allowed-ips {{ . }}
-{{ end }}
+{{ end -}}
+{{ with .DsnetConfig.Network6 -}}
+set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} allowed-ips {{ . }}
+{{ end -}}
+{{ range .DsnetConfig.Networks -}}
+set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} allowed-ips {{ . }}
+{{ end -}}
 commit; save
 `
 
@@ -122,7 +134,6 @@ func PrintPeerCfg(peer PeerConfig, conf *DsnetConfig) {
 		"Peer":        peer,
 		"DsnetConfig": conf,
 		"Keepalive":   time.Duration(KEEPALIVE).Seconds(),
-		"AllowedIPs":  allowedIPs,
 		"Cidrmask":    cidrmask,
 		"Address": net.IPNet{
 			IP: peer.IP,

--- a/add.go
+++ b/add.go
@@ -8,8 +8,12 @@ import (
 )
 
 const wgQuickPeerConf = `[Interface]
+{{ if gt (.DsnetConfig.Network.IPNet.IP | len) 0 -}}
 Address={{ .Peer.IP }}/{{ .CidrSize }}
+{{ end -}}
+{{ if gt (.DsnetConfig.Network6.IPNet.IP | len) 0 -}}
 Address={{ .Peer.IP6 }}/{{ .CidrSize6 }}
+{{ end -}}
 PrivateKey={{ .Peer.PrivateKey.Key }}
 {{- if .DsnetConfig.DNS }}
 DNS={{ .DsnetConfig.DNS }}
@@ -37,11 +41,15 @@ AllowedIPs={{ . }}
 
 // TODO use random wg0-wg999 to hopefully avoid conflict by default?
 const vyattaPeerConf = `configure
+{{ if gt (.DsnetConfig.Network.IPNet.IP | len) 0 -}}
 set interfaces wireguard wg0 address {{ .Peer.IP }}/{{ .CidrSize }}
+{{ end -}}
+{{ if gt (.DsnetConfig.Network6.IPNet.IP | len) 0 -}}
 set interfaces wireguard wg0 address {{ .Peer.IP6 }}/{{ .CidrSize6 }}
+{{ end -}}
 set interfaces wireguard wg0 route-allowed-ips true
 set interfaces wireguard wg0 private-key {{ .Peer.PrivateKey.Key }}
-set interfaces wireguard wg0 description {{ conf.InterfaceName }}
+set interfaces wireguard wg0 description {{ .DsnetConfig.InterfaceName }}
 {{- if .DsnetConfig.DNS }}
 #set service dns forwarding name-server {{ .DsnetConfig.DNS }}
 {{ end }}

--- a/add.go
+++ b/add.go
@@ -62,8 +62,8 @@ func Add() {
 	privateKey := GenerateJSONPrivateKey()
 	publicKey := privateKey.PublicKey()
 
-	IP := conf.MustAllocateIP(conf.Network.IPNet)
-	IP6 := conf.MustAllocateIP(conf.Network6.IPNet)
+	IP := conf.MustAllocateIP()
+	IP6 := conf.MustAllocateIP6()
 
 	peer := PeerConfig{
 		Owner:        owner,

--- a/add.go
+++ b/add.go
@@ -63,7 +63,7 @@ func Add() {
 	publicKey := privateKey.PublicKey()
 
 	IP := conf.MustAllocateIP(conf.Network.IPNet)
-	//IP6 := conf.MustAllocateIP(conf.Network6.IPNet)
+	IP6 := conf.MustAllocateIP(conf.Network6.IPNet)
 
 	peer := PeerConfig{
 		Owner:        owner,
@@ -74,7 +74,7 @@ func Add() {
 		PrivateKey:   privateKey, // omitted from server config JSON!
 		PresharedKey: GenerateJSONKey(),
 		IP:           IP,
-		//IP6:          IP6,
+		IP6:          IP6,
 		Networks:     []JSONIPNet{},
 	}
 

--- a/add.go
+++ b/add.go
@@ -24,11 +24,11 @@ Endpoint={{ .DsnetConfig.ExternalIP }}:{{ .DsnetConfig.ListenPort }}
 Endpoint={{ .DsnetConfig.ExternalIP6 }}:{{ .DsnetConfig.ListenPort }}
 {{ end -}}
 PersistentKeepalive={{ .Keepalive }}
-{{ with .DsnetConfig.Network -}}
-AllowedIPs={{ . }}
+{{ if gt (.DsnetConfig.Network.IPNet.IP | len) 0 -}}
+AllowedIPs={{ .DsnetConfig.Network }}
 {{ end -}}
-{{ with .DsnetConfig.Network6 -}}
-AllowedIPs={{ . }}
+{{ if gt (.DsnetConfig.Network6.IPNet.IP | len) 0 -}}
+AllowedIPs={{ .DsnetConfig.Network6 }}
 {{ end -}}
 {{ range .DsnetConfig.Networks -}}
 AllowedIPs={{ . }}
@@ -53,11 +53,11 @@ set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} en
 {{ end -}}
 set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} persistent-keepalive {{ .Keepalive }}
 set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} preshared-key {{ .Peer.PresharedKey.Key }}
-{{ with .DsnetConfig.Network -}}
-set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} allowed-ips {{ . }}
+{{ if gt (.DsnetConfig.Network.IPNet.IP | len) 0 -}}
+set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} allowed-ips {{ .DsnetConfig.Network }}
 {{ end -}}
-{{ with .DsnetConfig.Network6 -}}
-set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} allowed-ips {{ . }}
+{{ if gt (.DsnetConfig.Network6.IPNet.IP | len) 0 -}}
+set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} allowed-ips {{ .DsnetConfig.Network6 }}
 {{ end -}}
 {{ range .DsnetConfig.Networks -}}
 set interfaces wireguard wg0 peer {{ .DsnetConfig.PrivateKey.PublicKey.Key }} allowed-ips {{ . }}

--- a/add.go
+++ b/add.go
@@ -125,9 +125,16 @@ func Add() {
 }
 
 func PrintPeerCfg(peer PeerConfig, conf *DsnetConfig) {
-	allowedIPs := make([]JSONIPNet, len(conf.Networks)+2)
-	allowedIPs[0] = conf.Network
-	allowedIPs[1] = conf.Network6
+	allowedIPs := make([]JSONIPNet, 0, len(conf.Networks)+2)
+
+	if len(conf.Network.IPNet.Mask) > 0 {
+		allowedIPs = append(allowedIPs, conf.Network)
+	}
+
+	if len(conf.Network6.IPNet.Mask) > 0 {
+		allowedIPs = append(allowedIPs, conf.Network6)
+	}
+
 	allowedIPs = append(allowedIPs, conf.Networks...)
 
 	var peerConf string

--- a/add.go
+++ b/add.go
@@ -125,18 +125,6 @@ func Add() {
 }
 
 func PrintPeerCfg(peer PeerConfig, conf *DsnetConfig) {
-	allowedIPs := make([]JSONIPNet, 0, len(conf.Networks)+2)
-
-	if len(conf.Network.IPNet.Mask) > 0 {
-		allowedIPs = append(allowedIPs, conf.Network)
-	}
-
-	if len(conf.Network6.IPNet.Mask) > 0 {
-		allowedIPs = append(allowedIPs, conf.Network6)
-	}
-
-	allowedIPs = append(allowedIPs, conf.Networks...)
-
 	var peerConf string
 
 	switch os.Getenv("DSNET_OUTPUT") {

--- a/add.go
+++ b/add.go
@@ -62,7 +62,8 @@ func Add() {
 	privateKey := GenerateJSONPrivateKey()
 	publicKey := privateKey.PublicKey()
 
-	IP := conf.MustAllocateIP()
+	IP := conf.MustAllocateIP(conf.Network.IPNet)
+	//IP6 := conf.MustAllocateIP(conf.Network6.IPNet)
 
 	peer := PeerConfig{
 		Owner:        owner,
@@ -73,6 +74,7 @@ func Add() {
 		PrivateKey:   privateKey, // omitted from server config JSON!
 		PresharedKey: GenerateJSONKey(),
 		IP:           IP,
+		//IP6:          IP6,
 		Networks:     []JSONIPNet{},
 	}
 

--- a/add.go
+++ b/add.go
@@ -62,9 +62,6 @@ func Add() {
 	privateKey := GenerateJSONPrivateKey()
 	publicKey := privateKey.PublicKey()
 
-	IP := conf.MustAllocateIP()
-	IP6 := conf.MustAllocateIP6()
-
 	peer := PeerConfig{
 		Owner:        owner,
 		Hostname:     hostname,
@@ -73,9 +70,19 @@ func Add() {
 		PublicKey:    publicKey,
 		PrivateKey:   privateKey, // omitted from server config JSON!
 		PresharedKey: GenerateJSONKey(),
-		IP:           IP,
-		IP6:          IP6,
 		Networks:     []JSONIPNet{},
+	}
+
+	if len(conf.Network.IPNet.Mask) > 0 {
+		peer.IP = conf.MustAllocateIP()
+	}
+
+	if len(conf.Network6.IPNet.Mask) > 0 {
+		peer.IP6 = conf.MustAllocateIP6()
+	}
+
+	if len(conf.IP) == 0 && len(conf.IP6) == 0 {
+		ExitFail("No IPv4 or IPv6 network defined in config")
 	}
 
 	conf.MustAddPeer(peer)

--- a/add.go
+++ b/add.go
@@ -146,8 +146,8 @@ func PrintPeerCfg(peer PeerConfig, conf *DsnetConfig) {
 		"Peer":        peer,
 		"DsnetConfig": conf,
 		"Keepalive":   time.Duration(KEEPALIVE).Seconds(),
-		"CidrSize": cidrSize,
-		"CidrSize6": cidrSize6,
+		"CidrSize":    cidrSize,
+		"CidrSize6":   cidrSize6,
 	})
 	check(err)
 }

--- a/add.go
+++ b/add.go
@@ -3,6 +3,7 @@ package dsnet
 import (
 	"fmt"
 	"os"
+	"net"
 	"text/template"
 	"time"
 )
@@ -123,6 +124,14 @@ func PrintPeerCfg(peer PeerConfig, conf *DsnetConfig) {
 		"Keepalive":   time.Duration(KEEPALIVE).Seconds(),
 		"AllowedIPs":  allowedIPs,
 		"Cidrmask":    cidrmask,
+		"Address": net.IPNet{
+			IP: peer.IP,
+			Mask: conf.Network.IPNet.Mask,
+		},
+		"Address6": net.IPNet{
+			IP: peer.IP6,
+			Mask: conf.Network6.IPNet.Mask,
+		},
 	})
 	check(err)
 }

--- a/configtypes.go
+++ b/configtypes.go
@@ -11,6 +11,13 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
+type ipVersion int
+
+const (
+	IPv4 ipVersion = 4
+	IPv6 ipVersion = 6
+)
+
 // see https://github.com/WireGuard/wgctrl-go/blob/master/wgtypes/types.go for definitions
 type PeerConfig struct {
 	// Used to update DNS

--- a/configtypes.go
+++ b/configtypes.go
@@ -21,8 +21,8 @@ type PeerConfig struct {
 	// Description of what the host is and/or does
 	Description string `validate:"required,gte=1,lte=255"`
 	// Internal VPN IP address. Added to AllowedIPs in server config as a /32
-	IP    net.IP    `validate:"required`
-	IP6   net.IP    `validate:"required`
+	IP    net.IP
+	IP6   net.IP
 	Added time.Time `validate:"required"`
 	// TODO ExternalIP support (Endpoint)
 	//ExternalIP     net.UDPAddr `validate:"required,udp4_addr"`
@@ -45,8 +45,8 @@ type DsnetConfig struct {
 	// Network is chosen randomly when not specified
 	Network  JSONIPNet `validate:"required"`
 	Network6 JSONIPNet `validate:"required"`
-	IP       net.IP    `validate:"required"`
-	IP6      net.IP    `validate:"required"`
+	IP       net.IP
+	IP6      net.IP
 	DNS      net.IP
 	// extra networks available, will be added to AllowedIPs
 	Networks []JSONIPNet `validate:"required"`

--- a/configtypes.go
+++ b/configtypes.go
@@ -21,6 +21,7 @@ type PeerConfig struct {
 	Description string `validate:"required,gte=1,lte=255"`
 	// Internal VPN IP address. Added to AllowedIPs in server config as a /32
 	IP    net.IP    `validate:"required`
+	IP6   net.IP    `validate:"required`
 	Added time.Time `validate:"required"`
 	// TODO ExternalIP support (Endpoint)
 	//ExternalIP     net.UDPAddr `validate:"required,udp4_addr"`
@@ -40,9 +41,11 @@ type DsnetConfig struct {
 	InterfaceName string `validate:"required,gte=1,lte=255"`
 	// IP network from which to allocate automatic sequential addresses
 	// Network is chosen randomly when not specified
-	Network JSONIPNet `validate:"required"`
-	IP      net.IP    `validate:"required"`
-	DNS     net.IP
+	Network  JSONIPNet `validate:"required"`
+	Network6 JSONIPNet `validate:"required"`
+	IP       net.IP    `validate:"required"`
+	IP6      net.IP    `validate:"required"`
+	DNS      net.IP
 	// extra networks available, will be added to AllowedIPs
 	Networks []JSONIPNet `validate:"required"`
 	// TODO Default subnets to route via VPN
@@ -127,7 +130,7 @@ func (conf *DsnetConfig) MustRemovePeer(hostname string) {
 
 	// remove peer from slice, retaining order
 	copy(conf.Peers[peerIndex:], conf.Peers[peerIndex+1:]) // shift left
-	conf.Peers = conf.Peers[:len(conf.Peers)-1] // truncate
+	conf.Peers = conf.Peers[:len(conf.Peers)-1]            // truncate
 }
 
 func (conf DsnetConfig) IPAllocated(IP net.IP) bool {

--- a/configtypes.go
+++ b/configtypes.go
@@ -232,10 +232,14 @@ func (conf DsnetConfig) GetWgPeerConfigs() []wgtypes.PeerConfig {
 		presharedKey := peer.PresharedKey.Key
 
 		// AllowedIPs = private IP + defined networks
-		allowedIPs := make([]net.IPNet, len(peer.Networks)+1)
+		allowedIPs := make([]net.IPNet, len(peer.Networks)+2)
 		allowedIPs[0] = net.IPNet{
 			IP:   peer.IP,
 			Mask: net.IPMask{255, 255, 255, 255},
+		}
+		allowedIPs[1] = net.IPNet{
+			IP:   peer.IP6,
+			Mask: net.IPMask{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 		}
 
 		for i, net := range peer.Networks {

--- a/configtypes.go
+++ b/configtypes.go
@@ -154,12 +154,15 @@ func (conf DsnetConfig) IPAllocated(IP net.IP) bool {
 }
 
 // choose a free IP for a new Peer
-func (conf DsnetConfig) MustAllocateIP() net.IP {
-	network := conf.Network.IPNet
+func (conf DsnetConfig) MustAllocateIP(network net.IPNet) net.IP {
 	ones, bits := network.Mask.Size()
 	zeros := bits - ones
-	min := 1                // avoids network addr
-	max := (1 << zeros) - 2 // avoids broadcast addr + overflow
+
+	// avoids network addr
+	min := 1
+	// avoids broadcast addr + overflow. Note there is no broadcast addr with
+	// IPv6, but I don't care about losing one when there are so many!
+	max := (1 << zeros) - 2
 
 	for i := min; i <= max; i++ {
 		IP := make(net.IP, len(network.IP))

--- a/configtypes.go
+++ b/configtypes.go
@@ -11,13 +11,6 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
-type ipVersion int
-
-const (
-	IPv4 ipVersion = 4
-	IPv6 ipVersion = 6
-)
-
 // see https://github.com/WireGuard/wgctrl-go/blob/master/wgtypes/types.go for definitions
 type PeerConfig struct {
 	// Used to update DNS

--- a/configtypes.go
+++ b/configtypes.go
@@ -165,8 +165,9 @@ func (conf DsnetConfig) MustAllocateIP() net.IP {
 	// avoids broadcast addr + overflow
 	max := (1 << zeros) - 2
 
+	IP := make(net.IP, len(network.IP))
+
 	for i := min; i <= max; i++ {
-		IP := make(net.IP, len(network.IP))
 		// dst, src!
 		copy(IP, network.IP)
 
@@ -195,9 +196,10 @@ func (conf DsnetConfig) MustAllocateIP6() net.IP {
 	rbs := make([]byte, zeros)
 	rand.Seed(time.Now().UTC().UnixNano())
 
+	IP := make(net.IP, len(network.IP))
+
 	for i := 0; i <= 10000; i++ {
 		rand.Read(rbs)
-		IP := make(net.IP, len(network.IP))
 		// dst, src! Copy prefix of IP
 		copy(IP, network.IP)
 

--- a/configtypes.go
+++ b/configtypes.go
@@ -36,7 +36,7 @@ type PeerConfig struct {
 type DsnetConfig struct {
 	// domain to append to hostnames. Relies on separate DNS server for
 	// resolution. Informational only.
-	ExternalIP    net.IP `validate:"required"`
+	ExternalIP    net.IP
 	ExternalIP6   net.IP
 	ListenPort    int    `validate:"gte=1024,lte=65535"`
 	Domain        string `validate:"required,gte=1,lte=255"`

--- a/configtypes.go
+++ b/configtypes.go
@@ -2,8 +2,8 @@ package dsnet
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"os"
 	"time"
@@ -206,7 +206,6 @@ func (conf DsnetConfig) MustAllocateIP6() net.IP {
 		// OR the host part with the network part
 		for j := ones / 8; j < len(IP); j++ {
 			IP[j] = IP[j] | rbs[j]
-			fmt.Println("%d, %s", j, IP[j])
 		}
 
 		if !conf.IPAllocated(IP) {

--- a/configtypes.go
+++ b/configtypes.go
@@ -232,14 +232,26 @@ func (conf DsnetConfig) GetWgPeerConfigs() []wgtypes.PeerConfig {
 		presharedKey := peer.PresharedKey.Key
 
 		// AllowedIPs = private IP + defined networks
-		allowedIPs := make([]net.IPNet, len(peer.Networks)+2)
-		allowedIPs[0] = net.IPNet{
-			IP:   peer.IP,
-			Mask: net.IPMask{255, 255, 255, 255},
+		allowedIPs := make([]net.IPNet, 0, len(peer.Networks)+2)
+
+		if len(peer.IP) > 0 {
+			allowedIPs = append(
+				allowedIPs,
+				net.IPNet{
+					IP:   peer.IP,
+					Mask: net.IPMask{255, 255, 255, 255},
+				},
+			)
 		}
-		allowedIPs[1] = net.IPNet{
-			IP:   peer.IP6,
-			Mask: net.IPMask{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+
+		if len(peer.IP6) > 0 {
+			allowedIPs = append(
+				allowedIPs,
+				net.IPNet{
+					IP:   peer.IP6,
+					Mask: net.IPMask{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+				},
+			)
 		}
 
 		for i, net := range peer.Networks {

--- a/configtypes.go
+++ b/configtypes.go
@@ -74,6 +74,10 @@ func MustLoadDsnetConfig() *DsnetConfig {
 	err = validator.New().Struct(conf)
 	check(err)
 
+	if len(conf.ExternalIP) == 0 && len(conf.ExternalIP6) == 0 {
+		ExitFail("Config does not contain ExternalIP or ExternalIP6")
+	}
+
 	return &conf
 }
 

--- a/configtypes.go
+++ b/configtypes.go
@@ -37,6 +37,7 @@ type DsnetConfig struct {
 	// domain to append to hostnames. Relies on separate DNS server for
 	// resolution. Informational only.
 	ExternalIP    net.IP `validate:"required"`
+	ExternalIP6   net.IP
 	ListenPort    int    `validate:"gte=1024,lte=65535"`
 	Domain        string `validate:"required,gte=1,lte=255"`
 	InterfaceName string `validate:"required,gte=1,lte=255"`

--- a/configtypes.go
+++ b/configtypes.go
@@ -134,12 +134,12 @@ func (conf *DsnetConfig) MustRemovePeer(hostname string) {
 }
 
 func (conf DsnetConfig) IPAllocated(IP net.IP) bool {
-	if IP.Equal(conf.IP) {
+	if IP.Equal(conf.IP) || IP.Equal(conf.IP6) {
 		return true
 	}
 
 	for _, peer := range conf.Peers {
-		if IP.Equal(peer.IP) {
+		if IP.Equal(peer.IP) || IP.Equal(peer.IP6) {
 			return true
 		}
 

--- a/const.go
+++ b/const.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	// populated with LDFLAGS, see do-release.sh
-	VERSION = "unknown"
+	VERSION    = "unknown"
 	GIT_COMMIT = "unknown"
 	BUILD_DATE = "unknown"
 )

--- a/exttypes.go
+++ b/exttypes.go
@@ -12,7 +12,11 @@ type JSONIPNet struct {
 }
 
 func (n JSONIPNet) MarshalJSON() ([]byte, error) {
-	return []byte("\"" + n.IPNet.String() + "\""), nil
+	if len(n.IPNet.IP) == 0 {
+		return []byte("\"\""), nil
+	} else {
+		return []byte("\"" + n.IPNet.String() + "\""), nil
+	}
 }
 
 func (n *JSONIPNet) UnmarshalJSON(b []byte) error {
@@ -36,11 +40,7 @@ func (n *JSONIPNet) UnmarshalJSON(b []byte) error {
 }
 
 func (n *JSONIPNet) String() string {
-	if len(n.IPNet.IP) == 0 {
-		return "\"\""
-	} else {
-		return n.IPNet.String()
-	}
+	return n.IPNet.String()
 }
 
 type JSONKey struct {

--- a/exttypes.go
+++ b/exttypes.go
@@ -24,7 +24,11 @@ func (n *JSONIPNet) UnmarshalJSON(b []byte) error {
 }
 
 func (n *JSONIPNet) String() string {
-	return n.IPNet.String()
+	if len(n.IPNet.IP) == 0 {
+		return "\"\""
+	} else {
+		return n.IPNet.String()
+	}
 }
 
 type JSONKey struct {

--- a/exttypes.go
+++ b/exttypes.go
@@ -18,8 +18,12 @@ func (n JSONIPNet) MarshalJSON() ([]byte, error) {
 func (n *JSONIPNet) UnmarshalJSON(b []byte) error {
 	cidr := strings.Trim(string(b), "\"")
 	IP, IPNet, err := net.ParseCIDR(cidr)
-	IPNet.IP = IP
-	n.IPNet = *IPNet
+
+	if err == nil {
+		IPNet.IP = IP
+		n.IPNet = *IPNet
+	}
+
 	return err
 }
 

--- a/exttypes.go
+++ b/exttypes.go
@@ -17,6 +17,14 @@ func (n JSONIPNet) MarshalJSON() ([]byte, error) {
 
 func (n *JSONIPNet) UnmarshalJSON(b []byte) error {
 	cidr := strings.Trim(string(b), "\"")
+
+	if cidr == "" {
+		// Leave as empty/uninitialised IPNet. A bit like omitempty behaviour,
+		// but we can leave the field there and blank which is useful if the
+		// user wishes to add the cidr manually.
+		return nil
+	}
+
 	IP, IPNet, err := net.ParseCIDR(cidr)
 
 	if err == nil {

--- a/init.go
+++ b/init.go
@@ -38,7 +38,7 @@ func Init() {
 
 	conf.MustSave()
 
-	fmt.Printf("Config written to %s. Please check/edit.", CONFIG_FILE)
+	fmt.Printf("Config written to %s. Please check/edit.\n", CONFIG_FILE)
 }
 
 // get a random IPv4  /22 subnet on 10.0.0.0 (1023 hosts) (or /24?)

--- a/init.go
+++ b/init.go
@@ -77,7 +77,7 @@ func getExternalIP() net.IP {
 	// arbitrary external IP is used (one that's guaranteed to route outside.
 	// In this case, Google's DNS server. Doesn't actually need to be online.)
 	conn, err := net.Dial("udp", "8.8.8.8:53")
-	if err != nil {
+	if err == nil {
 		defer conn.Close()
 
 		localAddr := conn.LocalAddr().String()
@@ -111,7 +111,7 @@ func getExternalIP() net.IP {
 func getExternalIP6() net.IP {
 	var IP net.IP
 	conn, err := net.Dial("udp", "2001:4860:4860::8888:53")
-	if err != nil {
+	if err == nil {
 		defer conn.Close()
 
 		localAddr := conn.LocalAddr().String()
@@ -123,14 +123,15 @@ func getExternalIP6() net.IP {
 		Timeout: 5 * time.Second,
 	}
 	resp, err := client.Get("https://ipv6.icanhazip.com/")
-	check(err)
-	defer resp.Body.Close()
+	if err == nil {
+		defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
-		check(err)
-		IP = net.ParseIP(strings.TrimSpace(string(body)))
-		return IP
+		if resp.StatusCode == http.StatusOK {
+			body, err := ioutil.ReadAll(resp.Body)
+			check(err)
+			IP = net.ParseIP(strings.TrimSpace(string(body)))
+			return IP
+		}
 	}
 
 	return net.IP{}

--- a/init.go
+++ b/init.go
@@ -22,7 +22,7 @@ func Init() {
 		PrivateKey:    GenerateJSONPrivateKey(),
 		ListenPort:    DEFAULT_LISTEN_PORT,
 		Network:       getPrivateNet(),
-		Network6:      getULA(),
+		Network6:      getULANet(),
 		Peers:         []PeerConfig{},
 		Domain:        "dsnet",
 		ReportFile:    DEFAULT_REPORT_FILE,
@@ -32,7 +32,7 @@ func Init() {
 	}
 
 	conf.IP = conf.MustAllocateIP(conf.Network.IPNet)
-	//conf.IP6 = conf.MustAllocateIP(conf.Network6.IPNet)
+	conf.IP6 = conf.MustAllocateIP(conf.Network6.IPNet)
 
 	// DNS not set by default
 	//conf.DNS = IP
@@ -56,7 +56,7 @@ func getPrivateNet() JSONIPNet {
 	}
 }
 
-func getULA() JSONIPNet {
+func getULANet() JSONIPNet {
 	rbs := make([]byte, 5)
 	rand.Seed(time.Now().UTC().UnixNano())
 	rand.Read(rbs)

--- a/init.go
+++ b/init.go
@@ -31,8 +31,8 @@ func Init() {
 		Networks:      []JSONIPNet{},
 	}
 
-	conf.IP = conf.MustAllocateIP(conf.Network.IPNet)
-	conf.IP6 = conf.MustAllocateIP(conf.Network6.IPNet)
+	conf.IP = conf.MustAllocateIP()
+	conf.IP6 = conf.MustAllocateIP6()
 
 	// DNS not set by default
 	//conf.DNS = IP

--- a/init.go
+++ b/init.go
@@ -31,8 +31,9 @@ func Init() {
 		Networks:      []JSONIPNet{},
 	}
 
-	IP := conf.MustAllocateIP()
-	conf.IP = IP
+	conf.IP = conf.MustAllocateIP(conf.Network.IPNet)
+	//conf.IP6 = conf.MustAllocateIP(conf.Network6.IPNet)
+
 	// DNS not set by default
 	//conf.DNS = IP
 

--- a/init.go
+++ b/init.go
@@ -63,7 +63,7 @@ func getULA() JSONIPNet {
 	// fc00 prefix with 40 bit global id and zero (16 bit) subnet ID
 	return JSONIPNet{
 		IPNet: net.IPNet{
-			net.IP{0xfc, 0, rbs[0], rbs[1], rbs[2], rbs[3], rbs[4], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			net.IP{0xfc, 0, rbs[0], rbs[1], rbs[2], rbs[3], rbs[4], 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			net.IPMask{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0},
 		},
 	}

--- a/init.go
+++ b/init.go
@@ -35,6 +35,10 @@ func Init() {
 	conf.IP = conf.MustAllocateIP()
 	conf.IP6 = conf.MustAllocateIP6()
 
+	if len(conf.ExternalIP) == 0 && len(conf.ExternalIP6) == 0 {
+		ExitFail("Could not determine any external IP, v4 or v6")
+	}
+
 	// DNS not set by default
 	//conf.DNS = IP
 
@@ -116,7 +120,11 @@ func getExternalIP6() net.IP {
 
 		localAddr := conn.LocalAddr().String()
 		IP = net.ParseIP(strings.Split(localAddr, ":")[0])
-		return IP
+
+		// check is not a ULA
+		if IP[0] != 0xfd && IP[0] != 0xfc {
+			return IP
+		}
 	}
 
 	client := http.Client{

--- a/init.go
+++ b/init.go
@@ -66,7 +66,7 @@ func getULANet() JSONIPNet {
 	rand.Seed(time.Now().UTC().UnixNano())
 	rand.Read(rbs)
 
-	// fc00 prefix with 40 bit global id and zero (16 bit) subnet ID
+	// fd00 prefix with 40 bit global id and zero (16 bit) subnet ID
 	return JSONIPNet{
 		IPNet: net.IPNet{
 			net.IP{0xfd, 0, rbs[0], rbs[1], rbs[2], rbs[3], rbs[4], 0, 0, 0, 0, 0, 0, 0, 0, 0},

--- a/init.go
+++ b/init.go
@@ -64,7 +64,7 @@ func getULANet() JSONIPNet {
 	// fc00 prefix with 40 bit global id and zero (16 bit) subnet ID
 	return JSONIPNet{
 		IPNet: net.IPNet{
-			net.IP{0xfc, 0, rbs[0], rbs[1], rbs[2], rbs[3], rbs[4], 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			net.IP{0xfd, 0, rbs[0], rbs[1], rbs[2], rbs[3], rbs[4], 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			net.IPMask{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0},
 		},
 	}

--- a/init.go
+++ b/init.go
@@ -21,7 +21,8 @@ func Init() {
 	conf := DsnetConfig{
 		PrivateKey:    GenerateJSONPrivateKey(),
 		ListenPort:    DEFAULT_LISTEN_PORT,
-		Network:       getRandomNetwork(),
+		Network:       getPrivateNet(),
+		Network6:      getULA(),
 		Peers:         []PeerConfig{},
 		Domain:        "dsnet",
 		ReportFile:    DEFAULT_REPORT_FILE,
@@ -40,8 +41,8 @@ func Init() {
 	fmt.Printf("Config written to %s. Please check/edit.", CONFIG_FILE)
 }
 
-// get a random /22 subnet on 10.0.0.0 (1023 hosts) (or /24?)
-func getRandomNetwork() JSONIPNet {
+// get a random IPv4  /22 subnet on 10.0.0.0 (1023 hosts) (or /24?)
+func getPrivateNet() JSONIPNet {
 	rbs := make([]byte, 2)
 	rand.Seed(time.Now().UTC().UnixNano())
 	rand.Read(rbs)
@@ -50,6 +51,20 @@ func getRandomNetwork() JSONIPNet {
 		IPNet: net.IPNet{
 			net.IP{10, rbs[0], rbs[1] << 2, 0},
 			net.IPMask{255, 255, 252, 0},
+		},
+	}
+}
+
+func getULA() JSONIPNet {
+	rbs := make([]byte, 5)
+	rand.Seed(time.Now().UTC().UnixNano())
+	rand.Read(rbs)
+
+	// fc00 prefix with 40 bit global id and zero (16 bit) subnet ID
+	return JSONIPNet{
+		IPNet: net.IPNet{
+			net.IP{0xfc, 0, rbs[0], rbs[1], rbs[2], rbs[3], rbs[4], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			net.IPMask{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0},
 		},
 	}
 }

--- a/util.go
+++ b/util.go
@@ -9,7 +9,7 @@ import (
 
 func check(e error, optMsg ...string) {
 	if e != nil {
-		if (len(optMsg) > 0) {
+		if len(optMsg) > 0 {
 			ExitFail("%s - %s", e, strings.Join(optMsg, " "))
 		}
 		ExitFail("%s", e)


### PR DESCRIPTION
- [x] choose ULA network
- [x] check is allocated
- [x] allocate v6
- [x] move allocation out of loop (IPv4 allocation) (also wtf is going on there anyway?)
- [x] template generation
- [x] only allocate if network is defined for v4 and v6
- [x] address subnets should be in generated config
- [x] check for public ipv6
- [x] check init with and without IPv6
- [x] check there's an external IPv4 or IPv6 in config after looking up IPs
- [x] endpoint: use IPv6 if IPv4 is not available
- [x] fix saving as encoded <nil>
- [x] fix cidrmask for address in config (!?!?)
- [x] fix nil pointer dereference when parsing empty Network JSONIPnet (add)
- [x] only write allowed IPs that exist for peers (IPv4, ipv6) (Netoerk, Netowrk6)
- [x] with statements in templates invalid, correct
- [x] check vyatta/wg-quick configs are coherent
- [x] fix Network6": "\u003cnil\u003e", -- happens when omitted and then saved
- [x] printpeerctg and getwgpeerconfigs should add v4 and v6 conditionally
- [x] update getwgpeerconfigs !
- [x] update docs with v6 instrucitons (NAT, no NAT, etc)
