### PR TITLE
Implements PostUp and PostDown commands using `/bin/sh`

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -66,6 +66,14 @@ with [hugo](https://gohugo.io/)
 network overview page. The shortcode file is included in this repository under
 `etc/`.
 
+        "PostUp": ""
+        "PostDown": ""
+
+Allows a user to specify commands to run after the device is up or down. This is
+typcially a collection of `iptables` invocations. The commands are executed by
+`/bin/sh`. *NOTE* These commands run as root, so make sure you check that they
+are secure.
+
         "PrivateKey": "uC+xz3v1mfjWBHepwiCgAmPebZcY+EdhaHAvqX2r7U8=",
 
 The server private key, automatically generated and very sensitive!

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Main (automatically generated) configuration example:
         "Networks": [],
         "ReportFile": "/var/lib/dsnetreport.json",
         "PrivateKey": "uC+xz3v1mfjWBHepwiCgAmPebZcY+EdhaHAvqX2r7U8=",
+        "PostUp": "",
+        "PostDown" "",
         "Peers": [
             {
                 "Hostname": "test",

--- a/add.go
+++ b/add.go
@@ -151,7 +151,6 @@ func PrintPeerCfg(peer PeerConfig, conf *DsnetConfig) {
 		wgifSeed += int(b)
 	}
 
-
 	t := template.Must(template.New("peerConf").Parse(peerConf))
 	err := t.Execute(os.Stdout, map[string]interface{}{
 		"Peer":        peer,
@@ -162,7 +161,7 @@ func PrintPeerCfg(peer PeerConfig, conf *DsnetConfig) {
 		// vyatta requires an interface in range/format wg0-wg999
 		// deterministically choosing one in this range will probably allow use
 		// of the config without a colliding interface name
-		"Wgif":        fmt.Sprintf("wg%d", wgifSeed % 999),
+		"Wgif": fmt.Sprintf("wg%d", wgifSeed%999),
 	})
 	check(err)
 }

--- a/configtypes.go
+++ b/configtypes.go
@@ -51,9 +51,11 @@ type DsnetConfig struct {
 	// extra networks available, will be added to AllowedIPs
 	Networks []JSONIPNet `validate:"required"`
 	// TODO Default subnets to route via VPN
-	ReportFile string       `validate:"required"`
-	PrivateKey JSONKey      `validate:"required,len=44"`
-	Peers      []PeerConfig `validate:"dive"`
+	ReportFile string  `validate:"required"`
+	PrivateKey JSONKey `validate:"required,len=44"`
+	PostUp   string
+	PostDown string
+	Peers    []PeerConfig `validate:"dive"`
 }
 
 func MustLoadDsnetConfig() *DsnetConfig {

--- a/down.go
+++ b/down.go
@@ -7,6 +7,11 @@ import (
 func Down() {
 	conf := MustLoadDsnetConfig()
 	DelLink(conf)
+	RunPostDown(conf)
+}
+
+func RunPostDown(conf *DsnetConfig) {
+	ShellOut(conf.PostDown, "PostDown")
 }
 
 func DelLink(conf *DsnetConfig) {

--- a/reporttypes.go
+++ b/reporttypes.go
@@ -163,7 +163,7 @@ type PeerReport struct {
 	// date peer was added to dsnet config
 	Added time.Time
 	// Internal VPN IP address. Added to AllowedIPs in server config as a /32
-	IP net.IP
+	IP  net.IP
 	IP6 net.IP
 	// Last known external IP
 	ExternalIP net.IP

--- a/up.go
+++ b/up.go
@@ -10,6 +10,11 @@ func Up() {
 	conf := MustLoadDsnetConfig()
 	CreateLink(conf)
 	ConfigureDevice(conf)
+	RunPostUp(conf)
+}
+
+func RunPostUp(conf *DsnetConfig) {
+	ShellOut(conf.PostUp, "PostUp")
 }
 
 func CreateLink(conf *DsnetConfig) {

--- a/util.go
+++ b/util.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 )
 
@@ -33,6 +34,17 @@ func MustPromptString(prompt string, required bool) string {
 func ExitFail(format string, a ...interface{}) {
 	fmt.Fprintf(os.Stderr, "\033[31m"+format+"\033[0m\n", a...)
 	os.Exit(1)
+}
+
+func ShellOut(command string, name string) {
+	if command != "" {
+        fmt.Printf("Running %s commands:\n %s", name, command)
+		shell := exec.Command("/bin/sh", "-c", command)
+		err := shell.Run()
+		if err != nil {
+			ExitFail("%s '%s' failed", name, command, err)
+		}
+	}
 }
 
 func ConfirmOrAbort(format string, a ...interface{}) {


### PR DESCRIPTION
This introduces PostUp and PostDown in dsnet. PostUp and PostDown allow
the user to run arbitrary commands after the device is up or down. These
are typically used to change the firewall rules via iptables. A working
example would be

...
    "PostUp" : "iptables -A FORWARD -i dsnet -j ACCEPT; iptables -A FORWARD -o dsnet -j ACCEPT; iptables -t nat -A POSTROUTING -o ens2 -j MASQUERADE ",
    "PostDown" : "iptables -D FORWARD -i dsnet -j ACCEPT; iptables -D FORWARD -o dsnet -j ACCEPT; iptables -t nat -D POSTROUTING -o ens2 -j MASQUERADE ",
...

All commands are executed by `/bin/sh` and no filtering or sandboxing is
applied. Users of this should know what they are doing.

Fixes https://github.com/naggie/dsnet/issues/16