### PR TITLE
Failed to add ipv6 addr

### DIFF
--- a/configtypes.go
+++ b/configtypes.go
@@ -21,8 +21,8 @@ type PeerConfig struct {
 	// Description of what the host is and/or does
 	Description string `validate:"required,gte=1,lte=255"`
 	// Internal VPN IP address. Added to AllowedIPs in server config as a /32
-	IP    net.IP
-	IP6   net.IP
+	IP    net.IP    `validate:"required"`
+	IP6   net.IP    `validate:"required"`
 	Added time.Time `validate:"required"`
 	// TODO ExternalIP support (Endpoint)
 	//ExternalIP     net.UDPAddr `validate:"required,udp4_addr"`

--- a/up.go
+++ b/up.go
@@ -40,7 +40,7 @@ func CreateLink(conf *DsnetConfig) {
 
 	err = netlink.AddrAdd(link, addr)
 	if err != nil {
-		ExitFail("Could not add addr %s to interface %s", addr.IP, err)
+		ExitFail("Could not add ipv4 addr %s to interface %s", addr.IP, err)
 	}
 
 	addr6 := &netlink.Addr{
@@ -52,7 +52,7 @@ func CreateLink(conf *DsnetConfig) {
 
 	err = netlink.AddrAdd(link, addr6)
 	if err != nil {
-		ExitFail("Could not add addr %s to interface %s", addr.IP, err)
+		ExitFail("Could not add ipv6 addr %s to interface %s", addr.IP, err)
 	}
 
 	// bring up interface (UNKNOWN state instead of UP, a wireguard quirk)

--- a/up.go
+++ b/up.go
@@ -52,7 +52,7 @@ func CreateLink(conf *DsnetConfig) {
 
 	err = netlink.AddrAdd(link, addr6)
 	if err != nil {
-		ExitFail("Could not add ipv6 addr %s to interface %s", addr.IP, err)
+		ExitFail("Could not add ipv6 addr %s to interface %s", addr6.IP, err)
 	}
 
 	// bring up interface (UNKNOWN state instead of UP, a wireguard quirk)


### PR DESCRIPTION
This PR fixes an issue with not having the required IPv4 or IPv6 fields set. Where we call up we expected both IPv4 and IPv6 to be set.

So this PR is just the fix for this, however in my mind I'm more inclinced to say neither should be a dependency and instead if you don't include ipv4 or ipv6 config in your `dsnetconfig.json` file then you just get an interface with no address set and you are responsible for setting it.