### PR TITLE
Fallback to wireguard userspace implementation when necessary

### DIFF
--- a/const.go
+++ b/const.go
@@ -7,6 +7,7 @@ import (
 const (
 	// could be overridden in future via env
 	CONFIG_FILE = "/etc/dsnetconfig.json"
+	WG_USERSPACE_IMPLEMENTATION = "wireguard-go"
 
 	// these end up in the config file
 	DEFAULT_INTERFACE_NAME = "dsnet"

--- a/up.go
+++ b/up.go
@@ -34,7 +34,8 @@ func CreateLink(conf *DsnetConfig) {
 
 	err := netlink.LinkAdd(link)
 	if err != nil {
-		ExitFail("Could not add interface '%s' (%v)", conf.InterfaceName, err)
+		FailWithoutExit("Could not add interface '%s' (%v), falling back to the userspace implementation", conf.InterfaceName, err)
+		ShellOut(WG_USERSPACE_IMPLEMENTATION + " " + conf.InterfaceName, "Userspace implementation")
 	}
 
 	if len(conf.IP) != 0 {

--- a/util.go
+++ b/util.go
@@ -31,6 +31,10 @@ func MustPromptString(prompt string, required bool) string {
 	return text
 }
 
+func FailWithoutExit(format string, a ...interface{}) {
+	fmt.Fprintf(os.Stderr, "\033[31m"+format+"\033[0m\n", a...)
+}
+
 func ExitFail(format string, a ...interface{}) {
 	fmt.Fprintf(os.Stderr, "\033[31m"+format+"\033[0m\n", a...)
 	os.Exit(1)


### PR DESCRIPTION
If the kernelspace wireguard is not available, fall back to the wireguard userspace implementation (defaults to 'wireguard-go', controlled via the const.go file)

This will allow servers with older kernel versions, or servers that doesn't have (and cant, like openvz) wireguard module loaded, to use dsnet with a userspace wireguard implementation, like [Wireguard-go](https://git.zx2c4.com/wireguard-go/about/) 

Same as wg-quick, [line 94 Link](https://git.zx2c4.com/wireguard-tools/tree/src/wg-quick/linux.bash#n94),
[Wireguard-go](https://git.zx2c4.com/wireguard-go/about/) or any other userspace implementation (like wireguard-rs and boringtun) can be used

