### PR TITLE
Add CLI option to regenerate existing peer.

### DIFF
--- a/cmd/dsnet.go
+++ b/cmd/dsnet.go
@@ -45,6 +45,20 @@ var (
 		Short: "Add a new peer + sync",
 	}
 
+	configCmd = &cobra.Command{
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("Missing hostname argument")
+			}
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			dsnet.Config(args[0])
+		},
+		Use:   "config [hostname]",
+		Short: "Show config for peer",
+	}
+
 	upCmd = &cobra.Command{
 		Run: func(cmd *cobra.Command, args []string) {
 			dsnet.Up()
@@ -123,6 +137,7 @@ func main() {
 	// Adds subcommands.
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(addCmd)
+	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(upCmd)
 	rootCmd.AddCommand(syncCmd)
 	rootCmd.AddCommand(reportCmd)

--- a/cmd/dsnet.go
+++ b/cmd/dsnet.go
@@ -45,7 +45,7 @@ var (
 		Short: "Add a new peer + sync",
 	}
 
-	configCmd = &cobra.Command{
+	regenerateCmd = &cobra.Command{
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("Missing hostname argument")
@@ -53,10 +53,10 @@ var (
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			dsnet.Config(args[0])
+			dsnet.Regenerate(args[0])
 		},
-		Use:   "config [hostname]",
-		Short: "Show config for peer",
+		Use:   "regenerate [hostname]",
+		Short: "Regenerate keys and config for peer",
 	}
 
 	upCmd = &cobra.Command{
@@ -137,7 +137,7 @@ func main() {
 	// Adds subcommands.
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(addCmd)
-	rootCmd.AddCommand(configCmd)
+	rootCmd.AddCommand(regenerateCmd)
 	rootCmd.AddCommand(upCmd)
 	rootCmd.AddCommand(syncCmd)
 	rootCmd.AddCommand(reportCmd)

--- a/config.go
+++ b/config.go
@@ -1,0 +1,21 @@
+package dsnet
+
+import (
+	"fmt"
+)
+
+func Config(hostname string) {
+	conf := MustLoadDsnetConfig()
+	found := false
+
+	for _, peer := range conf.Peers {
+		if peer.Hostname == hostname {
+			PrintPeerCfg(&peer, conf)
+			found = true
+		}
+	}
+
+	if !found {
+		ExitFail(fmt.Sprintf("unknown hostname: %s", hostname))
+	}
+}

--- a/regenerate.go
+++ b/regenerate.go
@@ -4,12 +4,17 @@ import (
 	"fmt"
 )
 
-func Config(hostname string) {
+func Regenerate(hostname string) {
 	conf := MustLoadDsnetConfig()
 	found := false
 
+	privateKey := GenerateJSONPrivateKey()
+
 	for _, peer := range conf.Peers {
 		if peer.Hostname == hostname {
+			peer.PrivateKey = privateKey
+			peer.PublicKey = privateKey.PublicKey()
+			peer.PresharedKey = GenerateJSONKey()
 			PrintPeerCfg(&peer, conf)
 			found = true
 		}
@@ -18,4 +23,7 @@ func Config(hostname string) {
 	if !found {
 		ExitFail(fmt.Sprintf("unknown hostname: %s", hostname))
 	}
+
+	conf.MustSave()
+	MustConfigureDevice(conf)
 }


### PR DESCRIPTION
Dear @naggie,

I really quite enjoy your dsnet tool. I started somehting similar in python with some different ideas [f-koehler/wgmgr](https://github.com/f-koehler/wgmgr) but seeing that this tool already has some traction and is nicely portable thanks to go, I decided to use it instead from now on.

However, I was missing an option to regenerate the config for an existing peer. In this PR I outline how one could implement it (pardon the code its the first go I've ever written). Please let me know what you think.

Best regads, @f-koehler