### PR TITLE
GitHub action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,25 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15
+
+    - name: Build
+      run: go build -v ./cmd/dsnet.go
+
+    - name: Test
+      run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
         go-version: ${{ matrix.go }}
 
     - name: Build
-      run: GOARCH=${{ matrix.arch }} go build -v ./cmd/dsnet.go
+      run: GOOS=linux CGO_ENABLED=0 ${{ matrix.arch }} go build -v ./cmd/dsnet.go
 
     - name: Test
       run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,13 +10,16 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ "1.15", "1.16" ]
     steps:
     - uses: actions/checkout@v2
 
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ${{ matrix.go }}
 
     - name: Build
       run: go build -v ./cmd/dsnet.go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,9 @@ jobs:
         go: [ "1.15", "1.16" ]
         arch:
           - "GOARCH=amd64"
-          - "GOARCH=arm"
+          - "GOARCH=arm GOARM=5"
+          - "GOARCH=arm GOARM=6"
+          - "GOARCH=arm GOARM=7"
           - "GOARCH=arm64"
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,10 @@ jobs:
     strategy:
       matrix:
         go: [ "1.15", "1.16" ]
+        arch:
+          - "GOARCH=amd64"
+          - "GOARCH=arm"
+          - "GOARCH=arm64"
     steps:
     - uses: actions/checkout@v2
 
@@ -22,7 +26,7 @@ jobs:
         go-version: ${{ matrix.go }}
 
     - name: Build
-      run: go build -v ./cmd/dsnet.go
+      run: GOARCH=${{ matrix.arch }} go build -v ./cmd/dsnet.go
 
     - name: Test
       run: go test -v ./...


### PR DESCRIPTION
Dear @naggie,

please consider this PR for a Github action that automatically compiles the code (as discussed in #50). Currently it builds for the following architectures:

* `x86_64`
* `arm`:
  * `v5`
  * `v6`
  * `v7`
* `arm64` (`armv8`)

Adding more is straightforward.
Two different go versions are used:

* `1.15`
* `1.16`

I discovered [this nice website](https://endoflife.date/go) which tells you which go versions are supported. It is necessary to manually update the action from time to time.

As a next step it would be nice to add an action to automate releases. I do this for some python projects and it really saves a lot of time. But I think this action is a good start and enough for now.

With my best regards,
@f-koehler 