### PR TITLE
Fix bug in regenerate command which did not update the dsnetconfig.json file

### DIFF
--- a/regenerate.go
+++ b/regenerate.go
@@ -18,8 +18,13 @@ func Regenerate(hostname string, confirm bool) {
 			peer.PrivateKey = privateKey
 			peer.PublicKey = privateKey.PublicKey()
 			peer.PresharedKey = GenerateJSONKey()
+
+			conf.MustRemovePeer(hostname)
 			PrintPeerCfg(&peer, conf)
 			found = true
+			conf.MustAddPeer(peer)
+
+			break
 		}
 	}
 


### PR DESCRIPTION
The peer config obtained in the loop is a copy. Modifying it does not change the actual config which is then written to disk. Therefore I call `MustRemovePeer` and `MustAddPeer` to actually modify the config before saving.

I have no idea why I did not notice it while testing. Noticed it in production :smile: 