### PR TITLE
Minimally addresses #71: don't swallow errors.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,10 +16,9 @@ import (
 
 var (
 	// Flags.
-	owner             string
-	description       string
-	confirm           bool
-	error_encountered bool
+	owner       string
+	description string
+	confirm     bool
 
 	// Commands.
 	rootCmd = &cobra.Command{}
@@ -38,34 +37,32 @@ var (
 	upCmd = &cobra.Command{
 		Use:   "up",
 		Short: "Create the interface, run pre/post up, sync",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			config := cli.MustLoadConfigFile()
 			server := cli.GetServer(config)
 			if e := server.Up(); e != nil {
-				fmt.Printf("error bringing up the network: %s\n", e)
-				error_encountered = true
+				return e
 			}
 			if e := utils.ShellOut(config.PostUp, "PostUp"); e != nil {
-				fmt.Printf("error bringing up the network: %s\n", e)
-				error_encountered = true
+				return e
 			}
+			return nil
 		},
 	}
 
 	downCmd = &cobra.Command{
 		Use:   "down",
 		Short: "Destroy the interface, run pre/post down",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			config := cli.MustLoadConfigFile()
 			server := cli.GetServer(config)
 			if e := server.DeleteLink(); e != nil {
-				fmt.Printf("error bringing up the network: %s\n", e)
-				error_encountered = true
+				return e
 			}
 			if e := utils.ShellOut(config.PostDown, "PostDown"); e != nil {
-				fmt.Printf("error bringing up the network: %s\n", e)
-				error_encountered = true
+				return e
 			}
+			return nil
 		},
 	}
 
@@ -183,9 +180,6 @@ func init() {
 func main() {
 	if err := rootCmd.Execute(); err != nil {
 		cli.ExitFail(err.Error())
-	}
-	if error_encountered {
-		os.Exit(1)
 	}
 	os.Exit(0)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -15,9 +16,10 @@ import (
 
 var (
 	// Flags.
-	owner       string
-	description string
-	confirm     bool
+	owner             string
+	description       string
+	confirm           bool
+	error_encountered bool
 
 	// Commands.
 	rootCmd = &cobra.Command{}
@@ -39,8 +41,14 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			config := cli.MustLoadConfigFile()
 			server := cli.GetServer(config)
-			server.Up()
-			utils.ShellOut(config.PostUp, "PostUp")
+			if e := server.Up(); e != nil {
+				fmt.Printf("error bringing up the network: %s\n", e)
+				error_encountered = true
+			}
+			if e := utils.ShellOut(config.PostUp, "PostUp"); e != nil {
+				fmt.Printf("error bringing up the network: %s\n", e)
+				error_encountered = true
+			}
 		},
 	}
 
@@ -50,8 +58,14 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			config := cli.MustLoadConfigFile()
 			server := cli.GetServer(config)
-			server.DeleteLink()
-			utils.ShellOut(config.PostDown, "PostDown")
+			if e := server.DeleteLink(); e != nil {
+				fmt.Printf("error bringing up the network: %s\n", e)
+				error_encountered = true
+			}
+			if e := utils.ShellOut(config.PostDown, "PostDown"); e != nil {
+				fmt.Printf("error bringing up the network: %s\n", e)
+				error_encountered = true
+			}
 		},
 	}
 
@@ -170,4 +184,8 @@ func main() {
 	if err := rootCmd.Execute(); err != nil {
 		cli.ExitFail(err.Error())
 	}
+	if error_encountered {
+		os.Exit(1)
+	}
+	os.Exit(0)
 }


### PR DESCRIPTION
Print the errors and return an error exit code if errors are encountered while setting up the network. This doesn't interrupt the execution, and it probably should; however, the patch is minimally invasive. It changes stdout by printing the error, and it changes the exit code; otherwise, the logic is unchanged.

The way I tested this was on a machine where IPv6 has been disabled. It could be similarly tested in a container or VM where ip6 has been disabled. Here's an example run:

```
phaethusa ~ % sudo ./dsnet up
error bringing up the network: could not add ipv6 addr 2607:f7a0:16:5::c05e to interface permission denied
phaethusa ~ % echo $?
1
```