### PR TITLE
User keys

### DIFF
--- a/cmd/cli/add.go
+++ b/cmd/cli/add.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Add prompts for the required information and creates a new peer
-func Add(hostname, owner, description string, confirm bool) error {
+func Add(hostname string, readKey bool, owner, description string, confirm bool) error {
 	// TODO accept existing pubkey
 	config, err := LoadConfigFile()
 	if err != nil {
@@ -17,6 +17,13 @@ func Add(hostname, owner, description string, confirm bool) error {
 	}
 	server := GetServer(config)
 
+	var key string
+ 	if readKey {
+	 	key, err = PromptString("private key", true)
+		if err != nil {
+			return fmt.Errorf("%w - invalid input for private key", err)
+		}
+ 	}
 	if owner == "" {
 		owner, err = PromptString("owner", true)
 		if err != nil {
@@ -38,7 +45,7 @@ func Add(hostname, owner, description string, confirm bool) error {
 	// newline (not on stdout) to separate config
 	fmt.Fprintln(os.Stderr)
 
-	peer, err := lib.NewPeer(server, owner, hostname, description)
+	peer, err := lib.NewPeer(server, key, owner, hostname, description)
 	if err != nil {
 		return fmt.Errorf("%w - failed to get new peer", err)
 	}

--- a/cmd/cli/config.go
+++ b/cmd/cli/config.go
@@ -99,12 +99,6 @@ func LoadConfigFile() (*DsnetConfig, error) {
 	return &conf, nil
 }
 
-func MustLoadConfigFile() *DsnetConfig {
-	config, err := LoadConfigFile()
-	check(err, "failed to load configuration file")
-	return config
-}
-
 // Save writes the configuration to disk
 func (conf *DsnetConfig) Save() error {
 	configFile := viper.GetString("config_file")
@@ -115,12 +109,6 @@ func (conf *DsnetConfig) Save() error {
 		return err
 	}
 	return nil
-}
-
-// MustSave is like Save except it exits on error
-func (conf *DsnetConfig) MustSave() {
-	err := conf.Save()
-	check(err, "failed to save config file")
 }
 
 // AddPeer adds a provided peer to the Peers list in the conf
@@ -162,12 +150,6 @@ func (conf *DsnetConfig) AddPeer(peer lib.Peer) error {
 	return nil
 }
 
-// MustAddPeer is like AddPeer, except it exist on error
-func (conf *DsnetConfig) MustAddPeer(peer lib.Peer) {
-	err := conf.AddPeer(peer)
-	check(err)
-}
-
 // RemovePeer removes a peer from the peer list based on hostname
 func (conf *DsnetConfig) RemovePeer(hostname string) error {
 	peerIndex := -1
@@ -186,12 +168,6 @@ func (conf *DsnetConfig) RemovePeer(hostname string) error {
 	copy(conf.Peers[peerIndex:], conf.Peers[peerIndex+1:]) // shift left
 	conf.Peers = conf.Peers[:len(conf.Peers)-1]            // truncate
 	return nil
-}
-
-// MustRemovePeer is like RemovePeer, except it exits on error
-func (conf *DsnetConfig) MustRemovePeer(hostname string) {
-	err := conf.RemovePeer(hostname)
-	check(err)
 }
 
 func (conf DsnetConfig) GetWgPeerConfigs() []wgtypes.PeerConfig {

--- a/cmd/cli/init.go
+++ b/cmd/cli/init.go
@@ -24,12 +24,12 @@ func Init() error {
 	_, err := os.Stat(configFile)
 
 	if !os.IsNotExist(err) {
-		return wrapError(err, fmt.Sprintf("Refusing to overwrite existing %s", configFile))
+		return fmt.Errorf("%w - Refusing to overwrite existing %s", err, configFile)
 	}
 
 	privateKey, err := lib.GenerateJSONPrivateKey()
 	if err != nil {
-		return wrapError(err, "failed to generate private key")
+		return fmt.Errorf("%w - failed to generate private key", err)
 	}
 
 	externalIPV4, err := getExternalIP()
@@ -60,12 +60,12 @@ func Init() error {
 
 	ipv4, err := server.AllocateIP()
 	if err != nil {
-		return wrapError(err, "failed to allocate ipv4 address")
+		return fmt.Errorf("%w - failed to allocate ipv4 address", err)
 	}
 
 	ipv6, err := server.AllocateIP6()
 	if err != nil {
-		return wrapError(err, "failed to allocate ipv6 address")
+		return fmt.Errorf("%w - failed to allocate ipv6 address", err)
 	}
 
 	conf.IP = ipv4
@@ -75,7 +75,9 @@ func Init() error {
 		return fmt.Errorf("Could not determine any external IP, v4 or v6")
 	}
 
-	conf.MustSave()
+	if err := conf.Save(); err != nil {
+		return fmt.Errorf("%w - failed to save config file", err)
+	}
 
 	fmt.Printf("Config written to %s. Please check/edit.\n", configFile)
 	return nil

--- a/cmd/cli/remove.go
+++ b/cmd/cli/remove.go
@@ -2,11 +2,13 @@ package cli
 
 import "fmt"
 
-func Remove(hostname string, confirm bool) {
+func Remove(hostname string, confirm bool) error {
 	conf := MustLoadConfigFile()
 
 	err := conf.RemovePeer(hostname)
-	check(err, "failed to update config")
+	if err != nil {
+		return wrapError(err, "failed to update config")
+	}
 
 	if !confirm {
 		ConfirmOrAbort("Do you really want to remove %s?", hostname)
@@ -16,5 +18,8 @@ func Remove(hostname string, confirm bool) {
 	server := GetServer(conf)
 
 	err = server.ConfigureDevice()
-	check(err, fmt.Sprintf("failed to sync server config to wg interface: %s", server.InterfaceName))
+	if err != nil {
+		return wrapError(err, fmt.Sprintf("failed to sync server config to wg interface: %s", server.InterfaceName))
+	}
+	return nil
 }

--- a/cmd/cli/report.go
+++ b/cmd/cli/report.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -69,7 +70,7 @@ type PeerReport struct {
 	TransmitBytesSI   string
 }
 
-func GenerateReport() {
+func GenerateReport() error {
 	conf := MustLoadConfigFile()
 
 	wg, err := wgctrl.New()
@@ -79,12 +80,13 @@ func GenerateReport() {
 	dev, err := wg.Device(conf.InterfaceName)
 
 	if err != nil {
-		ExitFail("Could not retrieve device '%s' (%v)", conf.InterfaceName, err)
+		return wrapError(err, fmt.Sprintf("Could not retrieve device '%s'", conf.InterfaceName))
 	}
 
 	oldReport := MustLoadDsnetReport()
 	report := GetReport(dev, conf, oldReport)
 	report.MustSave()
+	return nil
 }
 
 func GetReport(dev *wgtypes.Device, conf *DsnetConfig, oldReport *DsnetReport) DsnetReport {

--- a/cmd/cli/sync.go
+++ b/cmd/cli/sync.go
@@ -1,15 +1,17 @@
 package cli
 
+import "fmt"
+
 func Sync() error {
 	// TODO check device settings first
 	conf, err := LoadConfigFile()
 	if err != nil {
-		return wrapError(err, "failed to load configuration file")
+		return fmt.Errorf("%w - failed to load configuration file", err)
 	}
 	server := GetServer(conf)
 	err = server.ConfigureDevice()
 	if err != nil {
-		return wrapError(err, "failed to sync device configuration")
+		return fmt.Errorf("%w - failed to sync device configuration", err)
 	}
 	return nil
 }

--- a/cmd/cli/sync.go
+++ b/cmd/cli/sync.go
@@ -1,10 +1,15 @@
 package cli
 
-func Sync() {
+func Sync() error {
 	// TODO check device settings first
 	conf, err := LoadConfigFile()
-	check(err, "failed to load configuration file")
+	if err != nil {
+		return wrapError(err, "failed to load configuration file")
+	}
 	server := GetServer(conf)
 	err = server.ConfigureDevice()
-	check(err, "failed to sync device configuration")
+	if err != nil {
+		return wrapError(err, "failed to sync device configuration")
+	}
+	return nil
 }

--- a/cmd/cli/types.go
+++ b/cmd/cli/types.go
@@ -27,22 +27,25 @@ func (k *JSONKey) UnmarshalJSON(b []byte) error {
 	return err
 }
 
-func GenerateJSONPrivateKey() JSONKey {
+func GenerateJSONPrivateKey() (JSONKey, error) {
 	privateKey, err := wgtypes.GeneratePrivateKey()
-
-	check(err)
+	if err != nil {
+		return JSONKey{}, err
+	}
 
 	return JSONKey{
 		Key: privateKey,
-	}
+	}, nil
 }
 
-func GenerateJSONKey() JSONKey {
+func GenerateJSONKey() (JSONKey, error) {
 	privateKey, err := wgtypes.GenerateKey()
 
-	check(err)
+	if err != nil {
+		return JSONKey{}, err
+	}
 
 	return JSONKey{
 		Key: privateKey,
-	}
+	}, err
 }

--- a/cmd/cli/util.go
+++ b/cmd/cli/util.go
@@ -42,6 +42,10 @@ func ExitFail(format string, a ...interface{}) {
 	os.Exit(1)
 }
 
+func wrapError(err error, s string) error {
+	return fmt.Errorf("\033[31m%s - %s\033[0m\n", err, s)
+}
+
 func MustPromptString(prompt string, required bool) string {
 	reader := bufio.NewReader(os.Stdin)
 	var text string

--- a/cmd/cli/util.go
+++ b/cmd/cli/util.go
@@ -1,5 +1,7 @@
 package cli
 
+// FIXME every function in this file has public scope, but only private references
+
 import (
 	"bufio"
 	"fmt"
@@ -8,15 +10,6 @@ import (
 
 	"github.com/naggie/dsnet/lib"
 )
-
-func check(e error, optMsg ...string) {
-	if e != nil {
-		if len(optMsg) > 0 {
-			ExitFail("%s - %s", e, strings.Join(optMsg, " "))
-		}
-		ExitFail("%s", e)
-	}
-}
 
 func jsonPeerToDsnetPeer(peers []PeerConfig) []lib.Peer {
 	libPeers := make([]lib.Peer, 0, len(peers))
@@ -37,16 +30,7 @@ func jsonPeerToDsnetPeer(peers []PeerConfig) []lib.Peer {
 	return libPeers
 }
 
-func ExitFail(format string, a ...interface{}) {
-	fmt.Fprintf(os.Stderr, "\033[31m"+format+"\033[0m\n", a...)
-	os.Exit(1)
-}
-
-func wrapError(err error, s string) error {
-	return fmt.Errorf("\033[31m%s - %s\033[0m\n", err, s)
-}
-
-func MustPromptString(prompt string, required bool) string {
+func PromptString(prompt string, required bool) (string, error) {
 	reader := bufio.NewReader(os.Stdin)
 	var text string
 	var err error
@@ -54,12 +38,15 @@ func MustPromptString(prompt string, required bool) string {
 	for text == "" {
 		fmt.Fprintf(os.Stderr, "%s: ", prompt)
 		text, err = reader.ReadString('\n')
-		check(err)
+		if err != nil {
+			return "", fmt.Errorf("%w - error getting input", err)
+		}
 		text = strings.TrimSpace(text)
 	}
-	return text
+	return text, nil
 }
 
+// FIXME is it critical for this to panic, or can we cascade the errors?
 func ConfirmOrAbort(format string, a ...interface{}) {
 	fmt.Fprintf(os.Stderr, format+" [y/n] ", a...)
 
@@ -73,7 +60,8 @@ func ConfirmOrAbort(format string, a ...interface{}) {
 	if input == "y\n" {
 		return
 	} else {
-		ExitFail("Aborted.")
+		fmt.Fprintf(os.Stderr, "\033[31mAborted.\033[0m\n")
+		os.Exit(1)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,8 +76,8 @@ var (
 			}
 			return nil
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			cli.Add(args[0], owner, description, confirm)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.Add(args[0], owner, description, confirm)
 		},
 	}
 
@@ -90,24 +90,24 @@ var (
 			}
 			return nil
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			cli.Regenerate(args[0], confirm)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.Regenerate(args[0], confirm)
 		},
 	}
 
 	syncCmd = &cobra.Command{
 		Use:   "sync",
 		Short: fmt.Sprintf("Update wireguard configuration from %s after validating", viper.GetString("config_file")),
-		Run: func(cmd *cobra.Command, args []string) {
-			cli.Sync()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.Sync()
 		},
 	}
 
 	reportCmd = &cobra.Command{
 		Use:   "report",
 		Short: fmt.Sprintf("Generate a JSON status report to the location configured in %s.", viper.GetString("config_file")),
-		Run: func(cmd *cobra.Command, args []string) {
-			cli.GenerateReport()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.GenerateReport()
 		},
 	}
 
@@ -122,8 +122,8 @@ var (
 
 			return nil
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			cli.Remove(args[0], confirm)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.Remove(args[0], confirm)
 		},
 	}
 
@@ -180,9 +180,6 @@ func init() {
 func main() {
 	if err := rootCmd.Execute(); err != nil {
 		cli.ExitFail(err.Error())
-	}
-	if error_encountered {
-		os.Exit(1)
 	}
 	os.Exit(0)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,10 +16,9 @@ import (
 
 var (
 	// Flags.
-	owner             string
-	description       string
-	confirm           bool
-	error_encountered bool
+	owner       string
+	description string
+	confirm     bool
 
 	// Commands.
 	rootCmd = &cobra.Command{}
@@ -38,34 +37,32 @@ var (
 	upCmd = &cobra.Command{
 		Use:   "up",
 		Short: "Create the interface, run pre/post up, sync",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			config := cli.MustLoadConfigFile()
 			server := cli.GetServer(config)
 			if e := server.Up(); e != nil {
-				fmt.Printf("error bringing up the network: %s\n", e)
-				error_encountered = true
+				return e
 			}
 			if e := utils.ShellOut(config.PostUp, "PostUp"); e != nil {
-				fmt.Printf("error bringing up the network: %s\n", e)
-				error_encountered = true
+				return e
 			}
+			return nil
 		},
 	}
 
 	downCmd = &cobra.Command{
 		Use:   "down",
 		Short: "Destroy the interface, run pre/post down",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			config := cli.MustLoadConfigFile()
 			server := cli.GetServer(config)
 			if e := server.DeleteLink(); e != nil {
-				fmt.Printf("error bringing up the network: %s\n", e)
-				error_encountered = true
+				return e
 			}
 			if e := utils.ShellOut(config.PostDown, "PostDown"); e != nil {
-				fmt.Printf("error bringing up the network: %s\n", e)
-				error_encountered = true
+				return e
 			}
+			return nil
 		},
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,8 +73,8 @@ var (
 	}
 
 	addCmd = &cobra.Command{
-		Use:   "add [hostname]",
-		Short: "Add a new peer + sync",
+		Use:   "add <hostname>",
+		Short: "Add a new peer + sync, optionally using a provided WireGuard private key",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Make sure we have the hostname
 			if len(args) != 1 {
@@ -83,7 +83,7 @@ var (
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return cli.Add(args[0], owner, description, confirm)
+			return cli.Add(args[0], userKey, owner, description, confirm)
 		},
 	}
 
@@ -140,6 +140,8 @@ var (
 		Use:   "version",
 		Short: "Print version",
 	}
+
+	userKey bool
 )
 
 func init() {
@@ -148,6 +150,7 @@ func init() {
 	addCmd.Flags().StringVar(&owner, "owner", "", "owner of the new peer")
 	addCmd.Flags().StringVar(&description, "description", "", "description of the new peer")
 	addCmd.Flags().BoolVar(&confirm, "confirm", false, "confirm")
+	addCmd.Flags().BoolVarP(&userKey, "key", "k", false, "User-supplied key on stdin")
 	removeCmd.Flags().BoolVar(&confirm, "confirm", false, "confirm")
 
 	// Environment variable handling.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,7 +38,10 @@ var (
 		Use:   "up",
 		Short: "Create the interface, run pre/post up, sync",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config := cli.MustLoadConfigFile()
+			config, err := cli.LoadConfigFile()
+			if err != nil {
+				return fmt.Errorf("%w - failure to load config file", err)
+			}
 			server := cli.GetServer(config)
 			if e := server.Up(); e != nil {
 				return e
@@ -54,7 +57,10 @@ var (
 		Use:   "down",
 		Short: "Destroy the interface, run pre/post down",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			config := cli.MustLoadConfigFile()
+			config, err := cli.LoadConfigFile()
+			if err != nil {
+				return fmt.Errorf("%w - failure to load config file", err)
+			}
 			server := cli.GetServer(config)
 			if e := server.DeleteLink(); e != nil {
 				return e
@@ -150,7 +156,8 @@ func init() {
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 
 	if err := viper.BindPFlag("output", rootCmd.PersistentFlags().Lookup("output")); err != nil {
-		cli.ExitFail(err.Error())
+		fmt.Fprintf(os.Stderr, "\033[31m%s\033[0m\n", err.Error())
+		os.Exit(1)
 	}
 
 	viper.SetDefault("config_file", "/etc/dsnetconfig.json")
@@ -179,7 +186,9 @@ func init() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		cli.ExitFail(err.Error())
+		// Because of side effects in viper, this gets printed twice
+		fmt.Fprintf(os.Stderr, "\033[31m%s\033[0m\n", err.Error())
+		os.Exit(1)
 	}
 	os.Exit(0)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -15,9 +16,10 @@ import (
 
 var (
 	// Flags.
-	owner       string
-	description string
-	confirm     bool
+	owner             string
+	description       string
+	confirm           bool
+	error_encountered bool
 
 	// Commands.
 	rootCmd = &cobra.Command{}
@@ -39,8 +41,14 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			config := cli.MustLoadConfigFile()
 			server := cli.GetServer(config)
-			server.Up()
-			utils.ShellOut(config.PostUp, "PostUp")
+			if e := server.Up(); e != nil {
+				fmt.Printf("error bringing up the network: %s\n", e)
+				error_encountered = true
+			}
+			if e := utils.ShellOut(config.PostUp, "PostUp"); e != nil {
+				fmt.Printf("error bringing up the network: %s\n", e)
+				error_encountered = true
+			}
 		},
 	}
 
@@ -50,8 +58,14 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			config := cli.MustLoadConfigFile()
 			server := cli.GetServer(config)
-			server.DeleteLink()
-			utils.ShellOut(config.PostDown, "PostDown")
+			if e := server.DeleteLink(); e != nil {
+				fmt.Printf("error bringing up the network: %s\n", e)
+				error_encountered = true
+			}
+			if e := utils.ShellOut(config.PostDown, "PostDown"); e != nil {
+				fmt.Printf("error bringing up the network: %s\n", e)
+				error_encountered = true
+			}
 		},
 	}
 
@@ -170,4 +184,8 @@ func main() {
 	if err := rootCmd.Execute(); err != nil {
 		cli.ExitFail(err.Error())
 	}
+	if error_encountered {
+		os.Exit(1)
+	}
+	os.Exit(0)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,8 +29,8 @@ var (
 			"Create %s containing default configuration + new keys without loading. Edit to taste.",
 			viper.GetString("config_file"),
 		),
-		Run: func(cmd *cobra.Command, args []string) {
-			cli.Init()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cli.Init()
 		},
 	}
 

--- a/lib/peer.go
+++ b/lib/peer.go
@@ -37,7 +37,7 @@ type Peer struct {
 	KeepAlive    time.Duration
 }
 
-func NewPeer(server *Server, owner string, hostname string, description string) (Peer, error) {
+func NewPeer(server *Server, key, owner, hostname, description string) (Peer, error) {
 	if owner == "" {
 		return Peer{}, errors.New("missing owner")
 	}
@@ -45,9 +45,17 @@ func NewPeer(server *Server, owner string, hostname string, description string) 
 		return Peer{}, errors.New("missing hostname")
 	}
 
-	privateKey, err := GenerateJSONPrivateKey()
-	if err != nil {
-		return Peer{}, fmt.Errorf("failed to generate private key: %s", err)
+	var privateKey JSONKey
+	if key != "" {
+		userKey := &JSONKey{}
+		userKey.UnmarshalJSON([]byte(key))
+		privateKey = *userKey
+	} else {
+		var err error
+		privateKey, err = GenerateJSONPrivateKey()
+		if err != nil {
+			return Peer{}, fmt.Errorf("failed to generate private key: %s", err)
+		}
 	}
 	publicKey := privateKey.PublicKey()
 


### PR DESCRIPTION
Here's another one. This adds the ability to accept user-supplied private keys. Why? Because I have a dream that I'll be able to connect my mobile phone to **two** WireGuard subnets _at the same time_, but to do that, you have to use the same private key for both peers (because you can only supply one in the WireGuard Android client).  Here's how it works:

1. The user copies the base64 private key
2. The user runs the dsnet add function, and includes the `-k` switch
3. dsnet will ask the user to enter their private key
4. dsnet uses the key instead of generating a new one

Example:
```
phaethusa ~ % sudo ./dsnet add -k mynode
private key: RGlkIHlvdSB0aGluayBJIHdvdWxkIHBvc3QgYSBrZXk=
owner: Me
Description: My Phone

Do you want to add the above configuration? [y/n] y

[Interface]
Address=10.79.56.6/22
PrivateKey=RGlkIHlvdSB0aGluayBJIHdvdWxkIHBvc3QgYSBrZXk=

[Peer]
PublicKey=U3RvcCB0cnlpbmchIFRoaXMgaXMgY2Vuc29yZWRlZGQ=
PresharedKey=VGhpcyBpcyBhIHNpbGx5IGJpdCBvZiB0ZXh0LiAwMTI=
Endpoint=my.server.net:51820
PersistentKeepalive=0
AllowedIPs=10.79.56.0/22
```

This feature is backwards compatible; dsnet acts the same as it did before if the `-k` flag isn't provided.

This PR depends on the `error_cascade` PR. Sorry.