### PR TITLE
Add nix-shell for reproducible dev environment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,28 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    go
+
+    gnumake
+    upx
+
+    wireguard-tools
+
+    gopls
+    gotools # goimports, godoc, etc.
+    go-tools # staticcheck
+    delve # debugger
+  ];
+
+  CGO_ENABLED = "0";
+
+  shellHook = ''
+    echo "dsnet dev shell"
+    echo "  go $(go version | awk '{print $3}')"
+    echo ""
+    echo "  make quick   — fast build"
+    echo "  make build   — optimised build (upx)"
+    echo "  go test ./...— run tests"
+  '';
+}


### PR DESCRIPTION
Provides Go, make, upx, wireguard-tools, and editor tooling (gopls, staticcheck, delve).
Sets CGO_ENABLED=0